### PR TITLE
feat: Show Similiar blog posts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -419,6 +419,7 @@ dotnet_diagnostic.S3875.severity = none       # Remove this overload of 'operato
 dotnet_diagnostic.IDE0005.severity = none # IDE0005: Using directive is unnecessary
 dotnet_diagnostic.IDE0021.severity = suggestion # IDE0021: Use expression body for constructor
 dotnet_diagnostic.IDE0022.severity = suggestion # IDE0022: Use expression body for method
+dotnet_diagnostic.IDE0055.severity = none # IDE0055: Fix formatting
 dotnet_diagnostic.IDE0058.severity = none # IDE0058: Expression value is never used
 dotnet_diagnostic.IDE0079.severity = warning # IDE0079: Remove unnecessary suppression
 dotnet_diagnostic.IDE0290.severity = none # IDE0290: Use primary constructor
@@ -443,6 +444,7 @@ dotnet_diagnostic.CA1055.severity = none # CA1055: Uri return values should not 
 dotnet_diagnostic.CA1056.severity = none # CA1056: Uri properties should not be strings
 dotnet_diagnostic.CA1812.severity = none # CA1812: Avoid uninstantiated internal classes
 dotnet_diagnostic.CA2201.severity = suggestion # CA2201: Do not raise reserved exception types
+dotnet_diagnostic.CA2227.severity = suggestion # CA2227: Collection properties should be read only
 
 # SonarAnalyzer.CSharp
 # https://rules.sonarsource.com/csharp

--- a/LinkDotNet.Blog.sln
+++ b/LinkDotNet.Blog.sln
@@ -19,6 +19,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		Readme.md = Readme.md
 		.editorconfig = .editorconfig
+		MIGRATION.md = MIGRATION.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{86FD0EB5-13F9-4F1C-ADA1-072EEFEFF1E9}"

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,26 @@
+# Migration Guide
+This document describes the changes that need to be made to migrate from one version of the blog to another.
+
+## 8.0 to 9.0
+A new `SimilarBlogPost` table is introduced to store similar blog posts.
+
+```sql
+CREATE TABLE SimilarBlogPosts
+(
+	Id [NVARCHAR](450) NOT NULL,
+	SimilarBlogPostIds NVARCHAR(1350) NOT NULL,
+)
+
+ALTER TABLE SimilarBlogPosts
+ADD CONSTRAINT PK_SimilarBlogPosts PRIMARY KEY (Id)
+```
+
+Add the following to the `appsettings.json`:
+
+```json
+{
+	"SimilarBlogPosts": true
+}
+```
+
+Or `false` if you don't want to use this feature.

--- a/docs/Setup/Configuration.md
+++ b/docs/Setup/Configuration.md
@@ -48,7 +48,8 @@ The appsettings.json file has a lot of options to customize the content of the b
 	"KofiToken": "ABC123",
 	"GithubSponsorName": "your-tag-here",
 	"ShowReadingIndicator": true,
-	"PatreonName": "your-tag-here"
+	"PatreonName": "your-tag-here",
+	"SimlarBlogPosts": "true"
 }
 ```
 
@@ -85,3 +86,4 @@ The appsettings.json file has a lot of options to customize the content of the b
 | GithubSponsorName                             | string         | Enables the "Github Sponsor" button which redirects to GitHub. Only pass in the user name instead of the url.                                                                     |
 | ShowReadingIndicator                          | boolean        | If set to `true` (default) a circle indicates the progress when a user reads a blog post (without comments).                                                                      |
 | PatreonName                                   | string         | Enables the "Become a patreon" button that redirects to patreon.com. Only pass the user name (public profile) as user name.                                                       |
+| SimilarBlogPosts                              | boolean        | If set to `true` (default) similar blog posts are shown at the end of a blog post.                                                                                                |

--- a/src/LinkDotNet.Blog.Domain/SimilarBlogPost.cs
+++ b/src/LinkDotNet.Blog.Domain/SimilarBlogPost.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace LinkDotNet.Blog.Domain;
+
+public class SimilarBlogPost : Entity
+{
+    public IList<string> SimilarBlogPostIds { get; set; } = [];
+}

--- a/src/LinkDotNet.Blog.Infrastructure/Persistence/Sql/BlogDbContext.cs
+++ b/src/LinkDotNet.Blog.Infrastructure/Persistence/Sql/BlogDbContext.cs
@@ -24,6 +24,8 @@ public sealed class BlogDbContext : DbContext
 
     public DbSet<BlogPostRecord> BlogPostRecords { get; set; }
 
+    public DbSet<SimilarBlogPost> SimilarBlogPosts { get; set; }
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         ArgumentNullException.ThrowIfNull(modelBuilder);

--- a/src/LinkDotNet.Blog.Infrastructure/Persistence/Sql/Mapping/SimilarBlogPostConfiguration.cs
+++ b/src/LinkDotNet.Blog.Infrastructure/Persistence/Sql/Mapping/SimilarBlogPostConfiguration.cs
@@ -1,0 +1,17 @@
+using LinkDotNet.Blog.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace LinkDotNet.Blog.Infrastructure.Persistence.Sql.Mapping;
+
+internal sealed class SimilarBlogPostConfiguration : IEntityTypeConfiguration<SimilarBlogPost>
+{
+    public void Configure(EntityTypeBuilder<SimilarBlogPost> builder)
+    {
+        builder.HasKey(b => b.Id);
+        builder.Property(b => b.Id)
+            .IsUnicode(false)
+            .ValueGeneratedOnAdd();
+        builder.Property(b => b.SimilarBlogPostIds).HasMaxLength(450 * 3).IsRequired();
+    }
+}

--- a/src/LinkDotNet.Blog.Web/ApplicationConfiguration.cs
+++ b/src/LinkDotNet.Blog.Web/ApplicationConfiguration.cs
@@ -17,6 +17,7 @@ public sealed record ApplicationConfiguration
     public bool IsAboutMeEnabled { get; set; }
 
     public bool IsGiscusEnabled { get; set; }
+
     public bool IsDisqusEnabled { get; set; }
 
     public string KofiToken { get; init; }
@@ -32,4 +33,6 @@ public sealed record ApplicationConfiguration
     public string PatreonName { get; init; }
 
     public bool IsPatreonEnabled => !string.IsNullOrEmpty(PatreonName);
+
+    public bool ShowSimilarPosts { get; init; }
 }

--- a/src/LinkDotNet.Blog.Web/Features/Admin/BlogPostEditor/Components/CreateNewBlogPost.razor
+++ b/src/LinkDotNet.Blog.Web/Features/Admin/BlogPostEditor/Components/CreateNewBlogPost.razor
@@ -1,5 +1,7 @@
 ﻿@using LinkDotNet.Blog.Domain
+@using NCronJob
 @inject IJSRuntime JSRuntime
+@inject IInstantJobRegistry InstantJobRegistry
 
 <div class="container">
 	<h3 class="fw-bold">@Title</h3>
@@ -119,6 +121,7 @@
     {
 	    canSubmit = false;
         await OnBlogPostCreated.InvokeAsync(model.ToBlogPost());
+        InstantJobRegistry.RunInstantJob<SimilarBlogPostJob>(parameter: true);
         ClearModel();
 	    canSubmit = true;
     }

--- a/src/LinkDotNet.Blog.Web/Features/BlogPostPublisher.cs
+++ b/src/LinkDotNet.Blog.Web/Features/BlogPostPublisher.cs
@@ -25,12 +25,15 @@ public sealed partial class BlogPostPublisher : IJob
 
     public async Task RunAsync(JobExecutionContext context, CancellationToken token)
     {
+        ArgumentNullException.ThrowIfNull(context);
+
         LogPublishStarting();
-        await PublishScheduledBlogPostsAsync();
+        var publishedPosts = await PublishScheduledBlogPostsAsync();
+        context.Output = publishedPosts;
         LogPublishStopping();
     }
 
-    private async Task PublishScheduledBlogPostsAsync()
+    private async Task<int> PublishScheduledBlogPostsAsync()
     {
         LogCheckingForScheduledBlogPosts();
 
@@ -46,6 +49,8 @@ public sealed partial class BlogPostPublisher : IJob
         {
             cacheInvalidator.Cancel();
         }
+
+        return blogPostsToPublish.Count;
     }
 
     private async Task<IPagedList<BlogPost>> GetScheduledBlogPostsAsync()

--- a/src/LinkDotNet.Blog.Web/Features/Services/Similiarity/SimiliarityCalculator.cs
+++ b/src/LinkDotNet.Blog.Web/Features/Services/Similiarity/SimiliarityCalculator.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LinkDotNet.Blog.Web.Features.Services.Similiarity;
+
+public static class SimilarityCalculator
+{
+    public static double CosineSimilarity(Dictionary<string, double> vectorA, Dictionary<string, double> vectorB)
+    {
+        ArgumentNullException.ThrowIfNull(vectorA);
+        ArgumentNullException.ThrowIfNull(vectorB);
+
+        var dotProduct = 0d;
+        var magnitudeA = 0d;
+
+        foreach (var term in vectorA.Keys)
+        {
+            if (vectorB.TryGetValue(term, out var value))
+            {
+                dotProduct += vectorA[term] * value;
+            }
+            magnitudeA += Math.Pow(vectorA[term], 2);
+        }
+
+        var magnitudeB = vectorB.Values.Sum(value => Math.Pow(value, 2));
+
+        return dotProduct / (Math.Sqrt(magnitudeA) * Math.Sqrt(magnitudeB));
+    }
+}

--- a/src/LinkDotNet.Blog.Web/Features/Services/Similiarity/TextProcessor.cs
+++ b/src/LinkDotNet.Blog.Web/Features/Services/Similiarity/TextProcessor.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace LinkDotNet.Blog.Web.Features.Services.Similiarity;
+
+public static partial class TextProcessor
+{
+    private static readonly char[] Separator = [' '];
+
+    public static IReadOnlyCollection<string> TokenizeAndNormalize(IEnumerable<string> texts)
+        => texts.SelectMany(TokenizeAndNormalize).ToList();
+
+    private static IReadOnlyCollection<string> TokenizeAndNormalize(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+
+        text = text.ToUpperInvariant();
+        text = TokenRegex().Replace(text, " ");
+        return [..text.Split(Separator, StringSplitOptions.RemoveEmptyEntries)];
+    }
+
+    [GeneratedRegex(@"[^a-z0-9\s]")]
+    private static partial Regex TokenRegex();
+}

--- a/src/LinkDotNet.Blog.Web/Features/Services/Similiarity/TfIdfVectorizer.cs
+++ b/src/LinkDotNet.Blog.Web/Features/Services/Similiarity/TfIdfVectorizer.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LinkDotNet.Blog.Web.Features.Services.Similiarity;
+
+public class TfIdfVectorizer
+{
+    private readonly IReadOnlyCollection<IReadOnlyCollection<string>> documents;
+    private readonly Dictionary<string, double> idfScores;
+
+    public TfIdfVectorizer(IReadOnlyCollection<IReadOnlyCollection<string>> documents)
+    {
+        this.documents = documents;
+        idfScores = CalculateIdfScores();
+    }
+
+    public Dictionary<string, double> ComputeTfIdfVector(IReadOnlyCollection<string> targetDocument)
+    {
+        ArgumentNullException.ThrowIfNull(targetDocument);
+
+        var termFrequency = targetDocument.GroupBy(t => t).ToDictionary(g => g.Key, g => g.Count());
+        var tfidfVector = new Dictionary<string, double>();
+
+        foreach (var term in termFrequency.Keys)
+        {
+            var tf = termFrequency[term] / (double)targetDocument.Count;
+            var idf = idfScores.TryGetValue(term, out var score) ? score : 0;
+            tfidfVector[term] = tf * idf;
+        }
+
+        return tfidfVector;
+    }
+
+    private Dictionary<string, double> CalculateIdfScores()
+    {
+        var termDocumentFrequency = new Dictionary<string, int>();
+        var scores = new Dictionary<string, double>();
+
+        foreach (var term in documents.Select(document => document.Distinct()).SelectMany(terms => terms))
+        {
+            if (!termDocumentFrequency.TryGetValue(term, out var value))
+            {
+                value = 0;
+                termDocumentFrequency[term] = value;
+            }
+            termDocumentFrequency[term] = ++value;
+        }
+
+        foreach (var term in termDocumentFrequency.Keys)
+        {
+            scores[term] = Math.Log(documents.Count / (double)termDocumentFrequency[term]);
+        }
+
+        return scores;
+    }
+}

--- a/src/LinkDotNet.Blog.Web/Features/ShowBlogPost/Components/BlogPostAdminActions.razor
+++ b/src/LinkDotNet.Blog.Web/Features/ShowBlogPost/Components/BlogPostAdminActions.razor
@@ -1,14 +1,16 @@
 ﻿@using LinkDotNet.Blog.Domain
 @using LinkDotNet.Blog.Infrastructure.Persistence
+@using NCronJob
 @inject NavigationManager NavigationManager
 @inject IToastService ToastService
 @inject IRepository<BlogPost> BlogPostRepository
+@inject IInstantJobRegistry InstantJobRegistry
 
 <AuthorizeView>
     <div class="blogpost-admin">
         <button id="edit-blogpost" type="button" class="btn btn-primary" @onclick="EditBlogPost" aria-label="edit">
             <i class="pencil"></i> Edit Blogpost</button>
-        <button id="delete-blogpost" type="button" class="btn btn-danger" @onclick="ShowConfirmDialog" aria-label="delete"><i class="bin2"></i> Delete 
+        <button id="delete-blogpost" type="button" class="btn btn-danger" @onclick="ShowConfirmDialog" aria-label="delete"><i class="bin2"></i> Delete
             Blogpost</button>
     </div>
     <ConfirmDialog @ref="ConfirmDialog" Title="Delete Blog Post" Content="Do you want to delete the Blog Post?" OnYesPressed="@DeleteBlogPostAsync">
@@ -18,16 +20,17 @@
 @code {
     [Parameter]
     public string BlogPostId { get; set; }
-    
+
     private ConfirmDialog ConfirmDialog { get; set; }
 
     private async Task DeleteBlogPostAsync()
     {
         await BlogPostRepository.DeleteAsync(BlogPostId);
+        InstantJobRegistry.RunInstantJob<SimilarBlogPostJob>(true);
         ToastService.ShowSuccess("The Blog Post was successfully deleted");
         NavigationManager.NavigateTo("/");
     }
-    
+
     private void ShowConfirmDialog()
     {
         ConfirmDialog.Open();

--- a/src/LinkDotNet.Blog.Web/Features/ShowBlogPost/Components/SimilarBlogPostSection.razor
+++ b/src/LinkDotNet.Blog.Web/Features/ShowBlogPost/Components/SimilarBlogPostSection.razor
@@ -1,0 +1,49 @@
+@using LinkDotNet.Blog.Domain
+@using LinkDotNet.Blog.Infrastructure.Persistence˘
+@inject IRepository<BlogPost> BlogPostRepository
+@inject IRepository<SimilarBlogPost> SimilarBlogPostJobRepository
+
+@if (similarBlogPosts.Count > 0)
+{
+	<div class="accordion my-5" id="archiveAccordion">
+		<div class="accordion-item">
+			<h2 class="accordion-header" id="headingOne">
+				<button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
+					Want to read more? Check out these related blog posts!
+				</button>
+			</h2>
+			<div id="collapseOne" class="accordion-collapse collapse" aria-labelledby="headingOne" data-bs-parent="#accordionExample">
+				<div class="row p-4">
+					@foreach (var relatedBlogPost in similarBlogPosts)
+					{
+						<div class="col pt-2">
+							<div class="card h-100">
+								<div class="card-body">
+									<h5 class="card-title fw-bold">@relatedBlogPost.Title</h5>
+									<p class="card-text">@MarkdownConverter.ToMarkupString(relatedBlogPost.ShortDescription)</p>
+								</div>
+								<a href="blogPost/@relatedBlogPost.Id/@relatedBlogPost.Slug" class="stretched-link"></a>
+							</div>
+						</div>
+					}
+				</div>
+			</div>
+		</div>
+	</div>
+}
+
+@code {
+	[Parameter] public BlogPost BlogPost { get; set; }
+
+	private IReadOnlyCollection<BlogPost> similarBlogPosts = [];
+
+	protected override async Task OnParametersSetAsync()
+	{
+		var similarBlogPostIds = await SimilarBlogPostJobRepository.GetByIdAsync(BlogPost.Id);
+		if (similarBlogPostIds is not null)
+		{
+			similarBlogPosts = await BlogPostRepository.GetAllAsync(
+				b => similarBlogPostIds.SimilarBlogPostIds.Contains(b.Id));
+		}
+	}
+}

--- a/src/LinkDotNet.Blog.Web/Features/ShowBlogPost/ShowBlogPostPage.razor
+++ b/src/LinkDotNet.Blog.Web/Features/ShowBlogPost/ShowBlogPostPage.razor
@@ -75,6 +75,10 @@ else
 				<ShareBlogPost></ShareBlogPost>
 			</div>
 			<DonationSection></DonationSection>
+			@if (AppConfiguration.Value.ShowSimilarPosts)
+			{
+				<SimilarBlogPostSection BlogPost="@BlogPost" />
+			}
 			<CommentSection></CommentSection>
 		</div>
 	</div>
@@ -109,11 +113,7 @@ else
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         await JsRuntime.InvokeVoidAsync("hljs.highlightAll");
-
-        if (firstRender)
-        {
-	        _ = UserRecordService.StoreUserRecordAsync();
-        }
+        _ = UserRecordService.StoreUserRecordAsync();
     }
 
     private async Task UpdateLikes(bool hasLiked)

--- a/src/LinkDotNet.Blog.Web/Features/SimilarBlogPostJob.cs
+++ b/src/LinkDotNet.Blog.Web/Features/SimilarBlogPostJob.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NCronJob;
+using LinkDotNet.Blog.Domain;
+using LinkDotNet.Blog.Infrastructure.Persistence;
+using LinkDotNet.Blog.Web.Features.Services.Similiarity;
+using Microsoft.Extensions.Options;
+
+namespace LinkDotNet.Blog.Web.Features;
+
+public class SimilarBlogPostJob : IJob
+{
+    private readonly IRepository<BlogPost> blogPostRepository;
+    private readonly IRepository<SimilarBlogPost> similarBlogPostRepository;
+    private readonly bool showSimilarPosts;
+
+    public SimilarBlogPostJob(
+        IRepository<BlogPost> blogPostRepository,
+        IRepository<SimilarBlogPost> similarBlogPostRepository,
+        IOptions<ApplicationConfiguration> applicationConfiguration)
+    {
+        ArgumentNullException.ThrowIfNull(applicationConfiguration);
+
+        this.blogPostRepository = blogPostRepository;
+        this.similarBlogPostRepository = similarBlogPostRepository;
+        showSimilarPosts = applicationConfiguration.Value.ShowSimilarPosts;
+    }
+
+    public async Task RunAsync(JobExecutionContext context, CancellationToken token)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (!showSimilarPosts)
+        {
+            return;
+        }
+
+        var isInstantJobTriggered = context.Parameter is not null;
+        var noJobPublished = context.ParentOutput is null or 0;
+        if (noJobPublished && !isInstantJobTriggered)
+        {
+            return;
+        }
+
+        var blogPosts = await blogPostRepository.GetAllByProjectionAsync(bp => new BlogPostSimilarity(bp.Id, bp.Title, bp.Tags, bp.ShortDescription));
+        var documents = blogPosts.Select(bp => TextProcessor.TokenizeAndNormalize(new[] { bp.Title, bp.ShortDescription }.Concat(bp.Tags))).ToList();
+
+        var similarities = blogPosts.Select(bp => GetSimilarityForBlogPost(bp, documents, blogPosts)).ToArray();
+        var ids = await similarBlogPostRepository.GetAllByProjectionAsync(s => s.Id);
+        await similarBlogPostRepository.DeleteBulkAsync(ids);
+        await similarBlogPostRepository.StoreBulkAsync(similarities);
+
+    }
+
+    private static SimilarBlogPost GetSimilarityForBlogPost(
+        BlogPostSimilarity blogPost,
+        List<IReadOnlyCollection<string>> documents,
+        IReadOnlyCollection<BlogPostSimilarity> blogPosts)
+    {
+        var target = TextProcessor.TokenizeAndNormalize(new[] { blogPost.Title, blogPost.ShortDescription }.Concat(blogPost.Tags));
+
+        var vectorizer = new TfIdfVectorizer(documents);
+        var targetVector = vectorizer.ComputeTfIdfVector(target);
+
+        var similarBlogPosts = blogPosts
+            .Select((bp, index) => new
+            {
+                BlogPost = bp,
+                Similarity = SimilarityCalculator.CosineSimilarity(targetVector, vectorizer.ComputeTfIdfVector(documents[index]))
+            })
+            .Where(s => s.BlogPost.Id != blogPost.Id)
+            .OrderByDescending(x => x.Similarity)
+            .Take(3)
+            .Select(s => s.BlogPost.Id)
+            .ToArray();
+
+        return new SimilarBlogPost { Id = blogPost.Id, SimilarBlogPostIds = similarBlogPosts };
+    }
+
+    private sealed record BlogPostSimilarity(string Id, string Title, IList<string> Tags, string ShortDescription);
+}

--- a/src/LinkDotNet.Blog.Web/LinkDotNet.Blog.Web.csproj
+++ b/src/LinkDotNet.Blog.Web/LinkDotNet.Blog.Web.csproj
@@ -10,7 +10,7 @@
         <PackageReference Include="Blazorise.Bootstrap5" Version="1.5.3" />
         <PackageReference Include="Blazorise.Markdown" Version="1.5.3" />
         <PackageReference Include="BuildBundlerMinifier" Version="3.2.449" PrivateAssets="all" />
-        <PackageReference Include="NCronJob" Version="2.8.3" />
+        <PackageReference Include="NCronJob" Version="2.8.4" />
         <PackageReference Include="Markdig" Version="0.37.0" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.0-preview.5.24306.11" />
         <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0-preview.5.24306.7" />
@@ -20,5 +20,9 @@
     <ItemGroup>
         <ProjectReference Include="..\LinkDotNet.Blog.Domain\LinkDotNet.Blog.Domain.csproj" />
         <ProjectReference Include="..\LinkDotNet.Blog.Infrastructure\LinkDotNet.Blog.Infrastructure.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Folder Include="Features\ShowBlogPost\Services\" />
     </ItemGroup>
 </Project>

--- a/src/LinkDotNet.Blog.Web/RegistrationExtensions/BackgroundServiceRegistrationExtensions.cs
+++ b/src/LinkDotNet.Blog.Web/RegistrationExtensions/BackgroundServiceRegistrationExtensions.cs
@@ -17,7 +17,10 @@ public static class BackgroundServiceRegistrationExtensions
 
         services.AddNCronJob(options =>
         {
-            options.AddJob<BlogPostPublisher>(p => p.WithCronExpression("* * * * *"));
+            options
+                .AddJob<BlogPostPublisher>(p => p.WithCronExpression("* * * * *"))
+                .ExecuteWhen(s => s.RunJob<SimilarBlogPostJob>());
+
             options.AddJob<TransformBlogPostRecordsJob>(p => p.WithCronExpression("0/10 * * * *"));
         });
     }

--- a/src/LinkDotNet.Blog.Web/appsettings.json
+++ b/src/LinkDotNet.Blog.Web/appsettings.json
@@ -35,5 +35,6 @@
 		"Heading": "Software Engineer",
 		"ProfilePictureUrl": "assets/profile-picture.webp"
 	},
-	"ShowReadingIndicator": true
+	"ShowReadingIndicator": true,
+	"ShowSimilarPosts": true
 }

--- a/tests/LinkDotNet.Blog.IntegrationTests/Web/Features/ShowBlogPost/Components/SimilarBlogPostSectionTests.cs
+++ b/tests/LinkDotNet.Blog.IntegrationTests/Web/Features/ShowBlogPost/Components/SimilarBlogPostSectionTests.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using LinkDotNet.Blog.Domain;
+using LinkDotNet.Blog.Infrastructure.Persistence;
+using LinkDotNet.Blog.Infrastructure.Persistence.Sql;
+using LinkDotNet.Blog.TestUtilities;
+using LinkDotNet.Blog.Web.Features.ShowBlogPost.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace LinkDotNet.Blog.IntegrationTests.Web.Features.ShowBlogPost.Components;
+
+public class SimilarBlogPostSectionTests : SqlDatabaseTestBase<BlogPost>
+{
+    [Fact]
+    public async Task ShouldShowSimilarBlogPosts()
+    {
+        var blogPost1 = new BlogPostBuilder().WithTitle("Title 1").Build();
+        var blogPost2 = new BlogPostBuilder().WithTitle("Title 2").Build();
+        var blogPost3 = new BlogPostBuilder().WithTitle("Title 3").Build();
+        await Repository.StoreAsync(blogPost1);
+        await Repository.StoreAsync(blogPost2);
+        await Repository.StoreAsync(blogPost3);
+        var similarBlogPost1 = new SimilarBlogPost
+        {
+            Id = blogPost1.Id,
+            SimilarBlogPostIds = [blogPost2.Id, blogPost3.Id]
+        };
+        await DbContext.SimilarBlogPosts.AddAsync(similarBlogPost1);
+        await DbContext.SaveChangesAsync();
+        await using var context = new BunitContext();
+        context.Services.AddScoped<IRepository<SimilarBlogPost>>(_ =>
+            new Repository<SimilarBlogPost>(DbContextFactory, Substitute.For<ILogger<Repository<SimilarBlogPost>>>()));
+        context.Services.AddScoped(_ => Repository);
+        
+        var cut = context.Render<SimilarBlogPostSection>(p => p.Add(s => s.BlogPost, blogPost1));
+
+        var elements = cut.WaitForElements(".card-title");
+        elements.Should().HaveCount(2);
+        elements.Should().Contain(p => p.TextContent == "Title 2");
+        elements.Should().Contain(p => p.TextContent == "Title 3");
+    }
+}

--- a/tests/LinkDotNet.Blog.IntegrationTests/Web/Features/ShowBlogPost/ShowBlogPostPageTests.cs
+++ b/tests/LinkDotNet.Blog.IntegrationTests/Web/Features/ShowBlogPost/ShowBlogPostPageTests.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Components.Web;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using NCronJob;
 
 namespace LinkDotNet.Blog.IntegrationTests.Web.Features.ShowBlogPost;
 
@@ -121,5 +122,6 @@ public class ShowBlogPostPageTests : SqlDatabaseTestBase<BlogPost>
         ctx.Services.AddScoped(_ => Substitute.For<IToastService>());
         ctx.Services.AddScoped(_ => Substitute.For<IUserRecordService>());
         ctx.Services.AddScoped(_ => Options.Create(new ApplicationConfiguration()));
+        ctx.Services.AddScoped(_ => Substitute.For<IInstantJobRegistry>());
     }
 }

--- a/tests/LinkDotNet.Blog.IntegrationTests/Web/Features/SimilarBlogPostJobTests.cs
+++ b/tests/LinkDotNet.Blog.IntegrationTests/Web/Features/SimilarBlogPostJobTests.cs
@@ -1,0 +1,77 @@
+using System.Threading;
+using System.Threading.Tasks;
+using LinkDotNet.Blog.Domain;
+using LinkDotNet.Blog.Infrastructure.Persistence.Sql;
+using LinkDotNet.Blog.TestUtilities;
+using LinkDotNet.Blog.Web;
+using LinkDotNet.Blog.Web.Features;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NCronJob;
+
+namespace LinkDotNet.Blog.IntegrationTests.Web.Features;
+
+public class SimilarBlogPostJobTests : SqlDatabaseTestBase<BlogPost>
+{
+    private readonly Repository<SimilarBlogPost> similarBlogPostRepository;
+    
+    public SimilarBlogPostJobTests()
+    {
+        similarBlogPostRepository = 
+            new Repository<SimilarBlogPost>(DbContextFactory, Substitute.For<ILogger<Repository<SimilarBlogPost>>>());
+    }
+    
+    [Fact]
+    public async Task ShouldCalculateSimilarBlogPosts()
+    {
+        var blogPost1 = new BlogPostBuilder().WithTitle("Title 1").Build();
+        var blogPost2 = new BlogPostBuilder().WithTitle("Title 2").Build();
+        var blogPost3 = new BlogPostBuilder().WithTitle("Title 3").Build();
+        await Repository.StoreAsync(blogPost1);
+        await Repository.StoreAsync(blogPost2);
+        await Repository.StoreAsync(blogPost3);
+        var config = Options.Create(new ApplicationConfiguration { ShowSimilarPosts = true });
+        
+        var job = new SimilarBlogPostJob(Repository, similarBlogPostRepository, config);
+        await job.RunAsync(new JobExecutionContext(typeof(SimilarBlogPostJob), true), CancellationToken.None);
+        
+        var similarBlogPosts = await similarBlogPostRepository.GetAllAsync();
+        similarBlogPosts.Should().HaveCount(3);
+    }
+    
+    [Fact]
+    public async Task ShouldNotCalculateWhenDisabledInApplicationConfiguration()
+    {
+        var blogPost1 = new BlogPostBuilder().WithTitle("Title 1").Build();
+        var blogPost2 = new BlogPostBuilder().WithTitle("Title 2").Build();
+        var blogPost3 = new BlogPostBuilder().WithTitle("Title 3").Build();
+        await Repository.StoreAsync(blogPost1);
+        await Repository.StoreAsync(blogPost2);
+        await Repository.StoreAsync(blogPost3);
+        var config = Options.Create(new ApplicationConfiguration { ShowSimilarPosts = false });
+        
+        var job = new SimilarBlogPostJob(Repository, similarBlogPostRepository, config);
+        await job.RunAsync(new JobExecutionContext(typeof(SimilarBlogPostJob), true), CancellationToken.None);
+        
+        var similarBlogPosts = await similarBlogPostRepository.GetAllAsync();
+        similarBlogPosts.Should().BeEmpty();
+    }
+    
+    [Fact]
+    public async Task ShouldNotCalculateWhenNotTriggeredAsInstantJob()
+    {
+        var blogPost1 = new BlogPostBuilder().WithTitle("Title 1").Build();
+        var blogPost2 = new BlogPostBuilder().WithTitle("Title 2").Build();
+        var blogPost3 = new BlogPostBuilder().WithTitle("Title 3").Build();
+        await Repository.StoreAsync(blogPost1);
+        await Repository.StoreAsync(blogPost2);
+        await Repository.StoreAsync(blogPost3);
+        var config = Options.Create(new ApplicationConfiguration { ShowSimilarPosts = true });
+        
+        var job = new SimilarBlogPostJob(Repository, similarBlogPostRepository, config);
+        await job.RunAsync(new JobExecutionContext(typeof(SimilarBlogPostJob), null), CancellationToken.None);
+        
+        var similarBlogPosts = await similarBlogPostRepository.GetAllAsync();
+        similarBlogPosts.Should().BeEmpty();
+    }
+}

--- a/tests/LinkDotNet.Blog.IntegrationTests/Web/Shared/Admin/BlogPostAdminActionsTests.cs
+++ b/tests/LinkDotNet.Blog.IntegrationTests/Web/Shared/Admin/BlogPostAdminActionsTests.cs
@@ -5,21 +5,28 @@ using LinkDotNet.Blog.Infrastructure.Persistence;
 using LinkDotNet.Blog.Web.Features.ShowBlogPost.Components;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
+using NCronJob;
 
 namespace LinkDotNet.Blog.IntegrationTests.Web.Shared.Admin;
 
-public class BlogPostAdminActionsTests
+public class BlogPostAdminActionsTests : BunitContext
 {
+    public BlogPostAdminActionsTests()
+    {
+        Services.AddSingleton(Substitute.For<IRepository<BlogPost>>());
+        Services.AddSingleton(Substitute.For<IToastService>());
+        Services.AddSingleton(Substitute.For<IInstantJobRegistry>());
+        AddAuthorization().SetAuthorized("s");
+    }
+    
     [Fact]
     public async Task ShouldDeleteBlogPostWhenOkClicked()
     {
         const string blogPostId = "2";
         var repositoryMock = Substitute.For<IRepository<BlogPost>>();
-        using var ctx = new BunitContext();
-        ctx.AddAuthorization().SetAuthorized("s");
-        ctx.Services.AddSingleton(repositoryMock);
-        ctx.Services.AddSingleton(Substitute.For<IToastService>());
-        var cut = ctx.Render<BlogPostAdminActions>(s => s.Add(p => p.BlogPostId, blogPostId));
+        Services.AddSingleton(repositoryMock);
+        
+        var cut = Render<BlogPostAdminActions>(s => s.Add(p => p.BlogPostId, blogPostId));
         cut.Find("#delete-blogpost").Click();
 
         cut.Find("#ok").Click();
@@ -32,11 +39,9 @@ public class BlogPostAdminActionsTests
     {
         const string blogPostId = "2";
         var repositoryMock = Substitute.For<IRepository<BlogPost>>();
-        using var ctx = new BunitContext();
-        ctx.AddAuthorization().SetAuthorized("s");
-        ctx.Services.AddSingleton(repositoryMock);
-        ctx.Services.AddSingleton(Substitute.For<IToastService>());
-        var cut = ctx.Render<BlogPostAdminActions>(s => s.Add(p => p.BlogPostId, blogPostId));
+        
+        Services.AddSingleton(repositoryMock);
+        var cut = Render<BlogPostAdminActions>(s => s.Add(p => p.BlogPostId, blogPostId));
         cut.Find("#delete-blogpost").Click();
 
         cut.Find("#cancel").Click();
@@ -48,13 +53,8 @@ public class BlogPostAdminActionsTests
     public void ShouldGoToEditPageOnEditClick()
     {
         const string blogPostId = "2";
-        var repositoryMock = Substitute.For<IRepository<BlogPost>>();
-        using var ctx = new BunitContext();
-        ctx.AddAuthorization().SetAuthorized("s");
-        ctx.Services.AddSingleton(repositoryMock);
-        ctx.Services.AddSingleton(Substitute.For<IToastService>());
-        var navigationManager = ctx.Services.GetRequiredService<NavigationManager>();
-        var cut = ctx.Render<BlogPostAdminActions>(s => s.Add(p => p.BlogPostId, blogPostId));
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        var cut = Render<BlogPostAdminActions>(s => s.Add(p => p.BlogPostId, blogPostId));
 
         cut.Find("#edit-blogpost").Click();
 

--- a/tests/LinkDotNet.Blog.UnitTests/Web/Features/Admin/BlogPostEditor/Components/CreateNewBlogPostTests.cs
+++ b/tests/LinkDotNet.Blog.UnitTests/Web/Features/Admin/BlogPostEditor/Components/CreateNewBlogPostTests.cs
@@ -6,8 +6,10 @@ using LinkDotNet.Blog.TestUtilities;
 using LinkDotNet.Blog.TestUtilities.Fakes;
 using LinkDotNet.Blog.Web.Features.Admin.BlogPostEditor.Components;
 using LinkDotNet.Blog.Web.Features.Components;
+using LinkDotNet.Blog.Web.Features.ShowBlogPost.Components;
 using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using NCronJob;
 
 namespace LinkDotNet.Blog.UnitTests.Web.Features.Admin.BlogPostEditor.Components;
 
@@ -17,6 +19,7 @@ public class CreateNewBlogPostTests : BunitContext
     {
         JSInterop.SetupVoid("hljs.highlightAll");
         ComponentFactories.Add<MarkdownTextArea, MarkdownFake>();
+        Services.AddScoped(_ => Substitute.For<IInstantJobRegistry>());
     }
 
     [Fact]

--- a/tests/LinkDotNet.Blog.UnitTests/Web/Features/ShowBlogPost/ShowBlogPostPageTests.cs
+++ b/tests/LinkDotNet.Blog.UnitTests/Web/Features/ShowBlogPost/ShowBlogPostPageTests.cs
@@ -12,17 +12,31 @@ using LinkDotNet.Blog.Web.Features.ShowBlogPost.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using NCronJob;
 
 namespace LinkDotNet.Blog.UnitTests.Web.Features.ShowBlogPost;
 
 public class ShowBlogPostPageTests : BunitContext
 {
+    public ShowBlogPostPageTests()
+    {
+        ComponentFactories.AddStub<SimilarBlogPostSection>();
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddScoped(_ => Substitute.For<IUserRecordService>());
+        Services.AddScoped(_ => Substitute.For<IToastService>());
+        Services.AddScoped(_ => Substitute.For<IInstantJobRegistry>());
+        Services.AddScoped(_ => Options.Create(new ApplicationConfiguration()));
+        AddAuthorization();
+        ComponentFactories.AddStub<PageTitle>();
+        ComponentFactories.AddStub<Like>();
+        ComponentFactories.AddStub<CommentSection>();
+    }
+    
     [Fact]
     public void ShouldShowLoadingAnimation()
     {
         const string blogPostId = "2";
         var repositoryMock = Substitute.For<IRepository<BlogPost>>();
-        SetupMocks();
         Services.AddScoped(_ => repositoryMock);
         repositoryMock.GetByIdAsync(blogPostId)
             .Returns(new ValueTask<BlogPost>(Task.Run(async () => 
@@ -45,7 +59,6 @@ public class ShowBlogPostPageTests : BunitContext
         var blogPost = new BlogPostBuilder().WithTitle("Title").Build();
         repositoryMock.GetByIdAsync("1").Returns(blogPost);
         Services.AddScoped(_ => repositoryMock);
-        SetupMocks();
 
         var cut = Render<ShowBlogPostPage>(
             p => p.Add(s => s.BlogPostId, "1"));
@@ -67,7 +80,6 @@ public class ShowBlogPostPageTests : BunitContext
             .Build();
         repositoryMock.GetByIdAsync("1").Returns(blogPost);
         Services.AddScoped(_ => repositoryMock);
-        SetupMocks();
 
         var cut = Render<ShowBlogPostPage>(
             p => p.Add(s => s.BlogPostId, "1"));
@@ -84,7 +96,6 @@ public class ShowBlogPostPageTests : BunitContext
             .Build();
         repositoryMock.GetByIdAsync("1").Returns(blogPost);
         Services.AddScoped(_ => repositoryMock);
-        SetupMocks();
 
         var cut = Render<ShowBlogPostPage>(
             p => p.Add(s => s.BlogPostId, "1"));
@@ -102,7 +113,6 @@ public class ShowBlogPostPageTests : BunitContext
             .Build();
         repositoryMock.GetByIdAsync("1").Returns(blogPost);
         Services.AddScoped(_ => repositoryMock);
-        SetupMocks();
 
         var cut = Render<ShowBlogPostPage>(
             p => p.Add(s => s.BlogPostId, "1"));
@@ -124,7 +134,6 @@ public class ShowBlogPostPageTests : BunitContext
             .Build();
         repositoryMock.GetByIdAsync("1").Returns(blogPost);
         Services.AddScoped(_ => repositoryMock);
-        SetupMocks();
         Services.AddScoped(_ => Options.Create(appConfiguration));
 
         var cut = Render<ShowBlogPostPage>(
@@ -143,23 +152,10 @@ public class ShowBlogPostPageTests : BunitContext
         blogPost.Id = "1";
         repositoryMock.GetByIdAsync("1").Returns(blogPost);
         Services.AddScoped(_ => repositoryMock);
-        SetupMocks();
         
         var cut = Render<ShowBlogPostPage>(
             p => p.Add(s => s.BlogPostId, "1"));
         
         cut.FindComponent<OgData>().Instance.CanonicalRelativeUrl.Should().Be("blogPost/1");
-    }
-
-    private void SetupMocks()
-    {
-        JSInterop.Mode = JSRuntimeMode.Loose;
-        Services.AddScoped(_ => Substitute.For<IUserRecordService>());
-        Services.AddScoped(_ => Substitute.For<IToastService>());
-        Services.AddScoped(_ => Options.Create(new ApplicationConfiguration()));
-        this.AddAuthorization();
-        ComponentFactories.AddStub<PageTitle>();
-        ComponentFactories.AddStub<Like>();
-        ComponentFactories.AddStub<CommentSection>();
     }
 }


### PR DESCRIPTION
Adding a feature where 3 related blog posts are shown under the main blog post.
This is done by a new background job that calculates similar blog posts and puts them into a new table.
Those entries are then shown.

<img width="893" alt="image" src="https://github.com/linkdotnet/Blog/assets/26365461/19144f39-6902-472b-82a1-c029c0ac7ddf">
