### PR TITLE
Short date culture fix

### DIFF
--- a/src/LinkDotNet.Blog.Web/Features/AboutMe/Components/Talk/TalkEntry.razor
+++ b/src/LinkDotNet.Blog.Web/Features/AboutMe/Components/Talk/TalkEntry.razor
@@ -3,7 +3,7 @@
 <li class="pb-1">
     <div class="row">
         <div class="col-10" id="talk-display-content">
-            <p class="text-body-secondary mb-0 small">@Talk.PublishedDate.ToString("dd/MM/yyyy")</p>
+            <p class="text-body-secondary mb-0 small">@Talk.PublishedDate.ToShortDateString()</p>
             <strong class="fs-5">@Talk.PresentationTitle</strong>
             <p id="talk-place" class="text-body-secondary">@Talk.Place</p>
             <div id="talk-description">

--- a/src/LinkDotNet.Blog.Web/Features/Archive/ArchivePage.razor
+++ b/src/LinkDotNet.Blog.Web/Features/Archive/ArchivePage.razor
@@ -2,6 +2,7 @@
 @using LinkDotNet.Blog.Infrastructure.Persistence
 @using LinkDotNet.Blog.Domain
 @using System.Collections.Immutable
+@using System.Globalization
 @inject IRepository<BlogPost> Repository
 
 <OgData Title="Archive" Description="Explore all blog posts."></OgData>
@@ -31,7 +32,7 @@
 								{
 									<li class="list-group-item">
 										<a href="/blogPost/@blogPost.Id/@blogPost.Slug" class="text-decoration-none">@blogPost.Title</a>
-										<span class="text-muted small ps-2">(@blogPost.UpdatedDate.ToString("MMM dd, yyyy"))</span>
+										<span class="text-muted small ps-2">(@blogPost.UpdatedDate.ToString("MMM dd, yyyy", CultureInfo.CurrentCulture))</span>
 									</li>
 								}
 							</ul>

--- a/src/LinkDotNet.Blog.Web/Features/Components/ShortBlogPost.razor
+++ b/src/LinkDotNet.Blog.Web/Features/Components/ShortBlogPost.razor
@@ -17,7 +17,7 @@
 				{
 					<li class="draft">Draft</li>
 				}
-				<li class="date me-4"><span>@BlogPost.UpdatedDate.ToString("dd/MM/yyyy")</span></li>
+				<li class="date me-4"><span>@BlogPost.UpdatedDate.ToShortDateString()</span></li>
 				@if (BlogPost.Tags.Any())
 				{
 					<li class="tags me-4">

--- a/src/LinkDotNet.Blog.Web/Features/ShowBlogPost/ShowBlogPostPage.razor
+++ b/src/LinkDotNet.Blog.Web/Features/ShowBlogPost/ShowBlogPostPage.razor
@@ -47,7 +47,7 @@ else if (BlogPost is not null)
 				<div class="text-dark-emphasis d-flex flex-wrap gap-2">
 					<div class="me-2">
 						<span class="date"></span>
-						<span class="ms-1">@BlogPost.UpdatedDate.ToString("dd/MM/yyyy")</span>
+						<span class="ms-1">@BlogPost.UpdatedDate.ToShortDateString()</span>
 					</div>
 					@if (BlogPost.Tags is not null && BlogPost.Tags.Any())
 					{


### PR DESCRIPTION
Previously were hardcoded to .ToString("dd/MM/yyyy") which could be confusing for some users.

For example: currently a date would show: `02/09/2024`, but now it would show as `9/2/2024` for the `en-US` culture