### PR TITLE
Update readtime text

### DIFF
--- a/src/LinkDotNet.Blog.Web/Features/Components/ShortBlogPost.razor
+++ b/src/LinkDotNet.Blog.Web/Features/Components/ShortBlogPost.razor
@@ -29,7 +29,7 @@
 						</ul>
 					</li>
 				}
-				<li class="read-time me-4">@BlogPost.ReadingTimeInMinutes min</li>
+				<li class="read-time me-4">@BlogPost.ReadingTimeInMinutes minute read</li>
 			</ul>
 		</div>
 		<div class="description">

--- a/src/LinkDotNet.Blog.Web/Features/ShowBlogPost/ShowBlogPostPage.razor
+++ b/src/LinkDotNet.Blog.Web/Features/ShowBlogPost/ShowBlogPostPage.razor
@@ -53,6 +53,8 @@ else if (BlogPost is not null)
 						<span class="date"></span>
 						<span class="ms-1">@BlogPost.UpdatedDate.ToShortDateString()</span>
 					</div>
+          				<span class="read-time"></span>
+          				<span class="me-2">@BlogPost.ReadingTimeInMinutes minute read</span>
 					@if (BlogPost.Tags is not null && BlogPost.Tags.Any())
 					{
 						<div class="d-flex align-items-center">

--- a/src/LinkDotNet.Blog.Web/Features/ShowBlogPost/ShowBlogPostPage.razor.css
+++ b/src/LinkDotNet.Blog.Web/Features/ShowBlogPost/ShowBlogPostPage.razor.css
@@ -23,6 +23,12 @@
     object-fit: cover;
 }
 
+.read-time:before {
+	font-family: 'icons';
+	font-weight: 900;
+	content: "\e94f";
+}
+
 @media only screen and (max-width: 700px) {
     .blog-outer-box .blog-container {
         width: 90%;


### PR DESCRIPTION
Updated read time text from: `XX min` To: `XX minute read`. Added read time to top of blog post.

I pulled the read time icon css from: `ShortBlogPost.razor.css` and put it into `ShowBlogPostPage.razor.css` - this okay or should it be removed from both and put somewhere more universal?

![blogpostpreviewreadtime](https://github.com/user-attachments/assets/14b8774c-c17a-4491-85a5-4056117b460e)
![blogpostreadtime](https://github.com/user-attachments/assets/472c4ecd-0582-456c-b13c-110d14846572)
