### PR TITLE
Update editor button background color

### DIFF
--- a/src/LinkDotNet.Blog.Web/wwwroot/css/basic.css
+++ b/src/LinkDotNet.Blog.Web/wwwroot/css/basic.css
@@ -143,6 +143,10 @@ code {
     color: red;
 }
 
+.editor-toolbar button.active, .editor-toolbar button:hover {
+    background: rgb(206, 206, 206, 0.5) !important;
+}
+
 #blazor-error-ui {
     background: lightyellow;
     bottom: 0;

--- a/src/LinkDotNet.Blog.Web/wwwroot/css/basic.css
+++ b/src/LinkDotNet.Blog.Web/wwwroot/css/basic.css
@@ -143,6 +143,7 @@ code {
     color: red;
 }
 
+/* Fixes white background/white icon for markdown editors */
 .editor-toolbar button.active, .editor-toolbar button:hover {
     background: rgb(206, 206, 206, 0.5) !important;
 }


### PR DESCRIPTION
Fix hard to see editor button when active/hover. Same in dark/light mode as Toolbar and markdown editor don't change.

**Before:**
![toolbarselectedbefore](https://github.com/user-attachments/assets/b48cd8e2-5111-4fcd-8658-0d52700eca00)
**After:**
![toolbarselectedafter](https://github.com/user-attachments/assets/6a8ee7ee-715c-4b57-92c0-c7022e3e35b4)


Fix found from: https://github.com/Ionaru/easy-markdown-editor/issues/327#issuecomment-892813538 I think this is fine unless we want to do the extra work to make a dark theme for easymde/Blazorize.Markdown.