### PR TITLE
Azure Blog Storage: Support for nested containers to upload files

### DIFF
--- a/docs/Media/Readme.md
+++ b/docs/Media/Readme.md
@@ -24,7 +24,7 @@ The following settings in `appsettings.json` control media upload functionality:
 | AuthenticationMode | string | Authentication method - either `Default` for Microsoft Entra ID or `ConnectionString` for connection string auth |
 | ConnectionString   | string | Azure Storage connection string (only used and mandatory when AuthenticationMode is `ConnectionString`)                          |
 | ServiceUrl         | string | Azure Blob Storage service URL (only used and mandatory when AuthenticationMode is `Default`)                                    |
-| ContainerName      | string | Name of the Azure Storage container to store uploaded files.                                                          |
+| ContainerName      | string | Name of the Azure Storage container to store uploaded files. It can be nested containers as well ``path/to/upload``                                                       |
 | CdnEndpoint | string | Optional CDN endpoint to use for uploaded images. If set, the blog will return this URL instead of the storage account URL for uploaded assets. |
 
 ## Authentication Methods


### PR DESCRIPTION
Currently, if the user sets a nested path like ``base/to/upload`` as ContainerName in the appsetting.json, the file will be uploaded into ``base`` container and ignore the nested parts.

I just added a few lines to support nested containers to upload files as it allows users to store files wherever they want.