### PR TITLE
Open RSS feed links in a new tab

### DIFF
--- a/src/LinkDotNet.Blog.Web/Features/Home/Components/NavMenu.razor
+++ b/src/LinkDotNet.Blog.Web/Features/Home/Components/NavMenu.razor
@@ -50,8 +50,8 @@
                         <i class="rss2"></i> RSS
                     </a>
                     <ul class="dropdown-menu" aria-labelledby="rssDropdown">
-	                    <li><a class="dropdown-item" href="/feed.rss" aria-label="RSS with All Posts">All Posts (Summary)</a></li>
-	                    <li><a class="dropdown-item" href="/feed.rss?withContent=true" aria-label="RSS with Full Content">Most Recent Posts (Full Content)</a></li>
+	                    <li><a class="dropdown-item" href="/feed.rss" target="_blank" aria-label="RSS with All Posts">All Posts (Summary)</a></li>
+	                    <li><a class="dropdown-item" href="/feed.rss?withContent=true" target="_blank" aria-label="RSS with Full Content">Most Recent Posts (Full Content)</a></li>
                     </ul>
                 </li>
 


### PR DESCRIPTION
I think opening a new tab for the RSS feed links is a little bit better experience for the user as it doesn't disrupt any minor state of the page (expanded Table of Contents, search, comments,...). 

_Another alternative or extra option could be to have a copy link button next to the relevant links in the popup RSS menu?_