### PR TITLE
Add blog series feature

### DIFF
--- a/src/LinkDotNet.Blog.Domain/BlogPost.cs
+++ b/src/LinkDotNet.Blog.Domain/BlogPost.cs
@@ -30,6 +30,8 @@ public sealed partial class BlogPost : Entity
 
     public int Likes { get; set; }
 
+    public int Order { get; set; }
+
     public bool IsScheduled => ScheduledPublishDate is not null;
 
     public string TagsAsString => string.Join(",", Tags);
@@ -39,6 +41,10 @@ public sealed partial class BlogPost : Entity
     public string Slug => GenerateSlug();
 
     public string? AuthorName { get; private set; }
+
+    public string? SeriesId { get; private set; }
+
+    public Series? Series { get; private set; }
 
     private string GenerateSlug()
     {
@@ -95,7 +101,9 @@ public sealed partial class BlogPost : Entity
         DateTime? scheduledPublishDate = null,
         IEnumerable<string>? tags = null,
         string? previewImageUrlFallback = null,
-        string? authorName = null)
+        string? authorName = null,
+        string? seriesId = null,
+        int order = 0)
     {
         if (scheduledPublishDate is not null && isPublished)
         {
@@ -116,7 +124,9 @@ public sealed partial class BlogPost : Entity
             IsPublished = isPublished,
             Tags = tags?.Select(t => t.Trim()).ToImmutableArray() ?? [],
             ReadingTimeInMinutes = ReadingTimeCalculator.CalculateReadingTime(content),
-            AuthorName = authorName
+            AuthorName = authorName,
+            SeriesId = seriesId,
+            Order = order
         };
 
         return blogPost;
@@ -126,6 +136,22 @@ public sealed partial class BlogPost : Entity
     {
         ScheduledPublishDate = null;
         IsPublished = true;
+    }
+
+    public void RemoveFromSeries()
+    {
+        SeriesId = null;
+        Series = null;
+        Order = 0;
+    }
+
+    public void AssignToSeries(string seriesId, int order)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(seriesId);
+
+        SeriesId = seriesId;
+        Series = null;
+        Order = order;
     }
 
     public void Update(BlogPost from)
@@ -148,5 +174,7 @@ public sealed partial class BlogPost : Entity
         Tags = from.Tags;
         ReadingTimeInMinutes = from.ReadingTimeInMinutes;
         AuthorName = from.AuthorName;
+        SeriesId = from.SeriesId;
+        Order = from.Order;
     }
 }

--- a/src/LinkDotNet.Blog.Domain/Series.cs
+++ b/src/LinkDotNet.Blog.Domain/Series.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace LinkDotNet.Blog.Domain;
+
+public sealed class Series : Entity
+{
+    public string Name { get; set; } = default!;
+}

--- a/src/LinkDotNet.Blog.Infrastructure/Persistence/MongoDB/Repository.cs
+++ b/src/LinkDotNet.Blog.Infrastructure/Persistence/MongoDB/Repository.cs
@@ -40,7 +40,20 @@ public sealed class Repository<TEntity> : IRepository<TEntity>
     {
         var filter = Builders<TEntity>.Filter.Eq(e => e.Id, id);
         using var result = await Collection.FindAsync(filter);
-        return await result.FirstOrDefaultAsync();
+        var entity = await result.FirstOrDefaultAsync();
+
+        if (entity is BlogPost { SeriesId: not null } blogPost)
+        {
+            var seriesCollection = database.GetCollection<Series>(nameof(Series));
+            var seriesFilter = Builders<Series>.Filter.Eq(s => s.Id, blogPost.SeriesId);
+            var seriesResult = await seriesCollection.FindAsync(seriesFilter);
+            var series = await seriesResult.FirstOrDefaultAsync();
+
+            var seriesProperty = typeof(BlogPost).GetProperty(nameof(BlogPost.Series));
+            seriesProperty?.SetValue(blogPost, series);
+        }
+
+        return entity;
     }
 
     public async ValueTask<IPagedList<TEntity>> GetAllAsync(Expression<Func<TEntity, bool>>? filter = null,
@@ -105,9 +118,9 @@ public sealed class Repository<TEntity> : IRepository<TEntity>
     {
         ArgumentNullException.ThrowIfNull(records);
 
-        if (records.Count != 0)
+        foreach (var record in records)
         {
-            await Collection.InsertManyAsync(records);
+            await StoreAsync(record);
         }
     }
 }

--- a/src/LinkDotNet.Blog.Infrastructure/Persistence/RavenDb/Repository.cs
+++ b/src/LinkDotNet.Blog.Infrastructure/Persistence/RavenDb/Repository.cs
@@ -36,7 +36,16 @@ public sealed class Repository<TEntity> : IRepository<TEntity>
     public async ValueTask<TEntity?> GetByIdAsync(string id)
     {
         using var session = documentStore.OpenAsyncSession();
-        return await session.LoadAsync<TEntity>(id);
+        var entity = await session.LoadAsync<TEntity>(id);
+
+        if (entity is BlogPost { SeriesId: not null } blogPost)
+        {
+            var series = await session.LoadAsync<Series>(blogPost.SeriesId);
+            var seriesProperty = typeof(BlogPost).GetProperty(nameof(BlogPost.Series));
+            seriesProperty?.SetValue(blogPost, series);
+        }
+
+        return entity;
     }
 
     public ValueTask<IPagedList<TEntity>> GetAllAsync(Expression<Func<TEntity, bool>>? filter = null,

--- a/src/LinkDotNet.Blog.Infrastructure/Persistence/Sql/BlogDbContext.cs
+++ b/src/LinkDotNet.Blog.Infrastructure/Persistence/Sql/BlogDbContext.cs
@@ -15,6 +15,8 @@ public sealed class BlogDbContext : DbContext
 
     public DbSet<BlogPost> BlogPosts { get; set; }
 
+    public DbSet<Series> Series { get; set; }
+
     public DbSet<ProfileInformationEntry> ProfileInformationEntries { get; set; }
 
     public DbSet<Skill> Skills { get; set; }
@@ -38,6 +40,7 @@ public sealed class BlogDbContext : DbContext
         ArgumentNullException.ThrowIfNull(modelBuilder);
 
         modelBuilder.ApplyConfiguration(new BlogPostConfiguration());
+        modelBuilder.ApplyConfiguration(new SeriesConfiguration());
         modelBuilder.ApplyConfiguration(new BlogPostRecordConfiguration());
         modelBuilder.ApplyConfiguration(new BlogPostTemplateConfiguration());
         modelBuilder.ApplyConfiguration(new BlogPostVersionConfiguration());

--- a/src/LinkDotNet.Blog.Infrastructure/Persistence/Sql/Mapping/BlogPostConfiguration.cs
+++ b/src/LinkDotNet.Blog.Infrastructure/Persistence/Sql/Mapping/BlogPostConfiguration.cs
@@ -19,9 +19,16 @@ internal sealed class BlogPostConfiguration : IEntityTypeConfiguration<BlogPost>
         builder.Property(x => x.ShortDescription).IsRequired();
         builder.Property(x => x.Likes).IsRequired();
         builder.Property(x => x.IsPublished).IsRequired();
+        builder.Property(x => x.Order).IsRequired();
 
         builder.Property(x => x.Tags).HasMaxLength(2048);
         builder.Property(x => x.AuthorName).HasMaxLength(256).IsRequired(false);
+        builder.Property(x => x.SeriesId).IsUnicode(false).IsRequired(false);
+
+        builder.HasOne(x => x.Series)
+            .WithMany()
+            .HasForeignKey(x => x.SeriesId)
+            .OnDelete(DeleteBehavior.SetNull);
 
         builder.HasIndex(x => new { x.IsPublished, x.UpdatedDate })
             .HasDatabaseName("IX_BlogPosts_IsPublished_UpdatedDate")

--- a/src/LinkDotNet.Blog.Infrastructure/Persistence/Sql/Mapping/SeriesConfiguration.cs
+++ b/src/LinkDotNet.Blog.Infrastructure/Persistence/Sql/Mapping/SeriesConfiguration.cs
@@ -1,0 +1,17 @@
+using LinkDotNet.Blog.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace LinkDotNet.Blog.Infrastructure.Persistence.Sql.Mapping;
+
+internal sealed class SeriesConfiguration : IEntityTypeConfiguration<Series>
+{
+    public void Configure(EntityTypeBuilder<Series> builder)
+    {
+        builder.HasKey(c => c.Id);
+        builder.Property(c => c.Id)
+            .IsUnicode(false)
+            .ValueGeneratedOnAdd();
+        builder.Property(x => x.Name).HasMaxLength(256).IsRequired();
+    }
+}

--- a/src/LinkDotNet.Blog.Infrastructure/Persistence/Sql/Repository.cs
+++ b/src/LinkDotNet.Blog.Infrastructure/Persistence/Sql/Repository.cs
@@ -39,7 +39,14 @@ public sealed partial class Repository<TEntity> : IRepository<TEntity>
     public async ValueTask<TEntity?> GetByIdAsync(string id)
     {
         await using var blogDbContext = await dbContextFactory.CreateDbContextAsync();
-        return await blogDbContext.Set<TEntity>().FirstOrDefaultAsync(b => b.Id == id);
+        var query = blogDbContext.Set<TEntity>().AsQueryable();
+
+        if (typeof(TEntity) == typeof(BlogPost))
+        {
+            query = query.Include("Series");
+        }
+
+        return await query.FirstOrDefaultAsync(b => b.Id == id);
     }
 
     public ValueTask<IPagedList<TEntity>> GetAllAsync(Expression<Func<TEntity, bool>>? filter = null,
@@ -150,7 +157,15 @@ public sealed partial class Repository<TEntity> : IRepository<TEntity>
             var count = 0;
             foreach (var record in records)
             {
-                await blogDbContext.Set<TEntity>().AddAsync(record);
+                if (string.IsNullOrEmpty(record.Id))
+                {
+                    await blogDbContext.Set<TEntity>().AddAsync(record);
+                }
+                else
+                {
+                    blogDbContext.Entry(record).State = EntityState.Modified;
+                }
+
                 if (++count % 1000 == 0)
                 {
                     LogBatch(count);

--- a/src/LinkDotNet.Blog.Web/Features/Admin/BlogPostEditor/Components/CreateNewBlogPost.razor
+++ b/src/LinkDotNet.Blog.Web/Features/Admin/BlogPostEditor/Components/CreateNewBlogPost.razor
@@ -9,6 +9,8 @@
 @inject IInstantJobRegistry InstantJobRegistry
 @inject IRepository<ShortCode> ShortCodeRepository
 @inject IRepository<BlogPostTemplate> TemplateRepository
+@inject IRepository<Series> SeriesRepository
+@inject IRepository<BlogPost> BlogPostRepository
 @inject IToastService ToastService
 @inject IOptions<ApplicationConfiguration> AppConfiguration
 @inject ICurrentUserService CurrentUserService
@@ -147,6 +149,77 @@
                                         @(BlogPost != null ? "Update Post" : "Create Post")
                                     </button>
                                 </div>
+                            </div>
+                        </div>
+
+                        <div class="card shadow-sm border-0 mb-4 hover-shadow-lg transition">
+                            <div class="card-header border-bottom-0 py-3">
+                                <h6 class="card-title mb-0 text-primary">Blog Series</h6>
+                            </div>
+                            <div class="card-body">
+                                <div class="mb-3">
+                                    <div class="d-flex justify-content-between align-items-center mb-1">
+                                        <label for="series" class="form-label fw-bold mb-0">Select Series</label>
+                                        <button id="toggle-add-series" type="button" class="btn btn-sm btn-outline-primary"
+                                                title="Add new series" aria-label="Add new series"
+                                                @onclick="ToggleAddSeries">
+                                            <i class="plus"></i> @(showAddSeries ? "Cancel Add" : "Add Series")
+                                        </button>
+                                    </div>
+                                    <InputSelect id="series" class="form-select" @bind-Value="model.SeriesId" @bind-Value:after="LoadPostsForSeries">
+                                        <option value="">None</option>
+                                        @foreach (var s in blogSeries)
+                                        {
+                                            <option value="@s.Id">@s.Name</option>
+                                        }
+                                    </InputSelect>
+                                    @if (showAddSeries)
+                                    {
+                                        <div class="input-group mt-2">
+                                            <input id="new-series-title" type="text" class="form-control"
+                                                   placeholder="New series title"
+                                                   maxlength="256"
+                                                   @bind="newSeriesTitle"
+                                                   @bind:event="oninput"
+                                                   @onkeydown="OnNewSeriesKeyDown" />
+                                            <button id="add-series" type="button" class="btn btn-primary"
+                                                    disabled="@string.IsNullOrWhiteSpace(newSeriesTitle)"
+                                                    @onclick="AddSeriesAsync">
+                                                Add Series
+                                            </button>
+                                        </div>
+                                    }
+                                </div>
+                                @if (!string.IsNullOrEmpty(model.SeriesId) && postsInSeries.Any())
+                                {
+                                    <div class="mt-3">
+                                        <h6 class="small fw-bold">Series Order:</h6>
+                                        <div class="list-group list-group-flush border rounded shadow-sm">
+                                            @for (var i = 0; i < postsInSeries.Count; i++)
+                                            {
+                                                var post = postsInSeries[i];
+                                                var displayOrder = i + 1;
+                                                <div class="list-group-item list-group-item-action d-flex justify-content-between align-items-center py-2 @(post.Id == BlogPostId ? "bg-primary fw-bold" : "")"
+                                                     style="cursor: move;"
+                                                     draggable="true"
+                                                     @ondragstart="() => OnDragStart(post)"
+                                                     @ondragover:preventDefault
+                                                     @ondrop="() => OnDrop(post)">
+                                                    <div class="text-truncate me-2" title="@post.Title">
+                                                        <i class="menu small text-muted me-1"></i> @post.Title
+                                                    </div>
+                                                    <span class="badge bg-secondary rounded-pill small">@displayOrder</span>
+                                                </div>
+                                            }
+                                        </div>
+                                        <small class="form-text text-muted mt-2 d-block" style="font-size: 0.75rem;">
+                                            Drag posts to reorder.
+                                        </small>
+                                    </div>
+                                }
+                                <small class="form-text text-muted mt-2 d-block">
+                                    Assigning a post to a series will display it as part of that series to readers.
+                                </small>
                             </div>
                         </div>
 
@@ -331,8 +404,15 @@
     private bool canSubmit = true;
     private IPagedList<ShortCode> shortCodes = PagedList<ShortCode>.Empty;
     private IPagedList<BlogPostTemplate> blogPostTemplates = PagedList<BlogPostTemplate>.Empty;
+    private IReadOnlyList<Series> blogSeries = [];
     private IReadOnlyList<string> availableTags = [];
     private IReadOnlyList<string> originalTags = [];
+
+    private List<BlogPost> postsInSeries = [];
+    private BlogPost? draggedPost;
+
+    private bool showAddSeries;
+    private string newSeriesTitle = string.Empty;
 
     private bool IsScheduled => model.ScheduledPublishDate.HasValue;
 
@@ -342,6 +422,7 @@
     {
         shortCodes = await ShortCodeRepository.GetAllAsync();
         blogPostTemplates = await TemplateRepository.GetAllAsync();
+        blogSeries = (await SeriesRepository.GetAllAsync(orderBy: s => s.Name, descending: false)).ToList();
         await LoadAvailableTagsAsync();
 
         if (AppConfiguration.Value.UseMultiAuthorMode)
@@ -364,6 +445,109 @@
         {
             versionHistory = await BlogPostVersionService.GetVersionHistoryAsync(BlogPostId);
         }
+
+        if (!string.IsNullOrEmpty(model.SeriesId))
+        {
+            await LoadPostsForSeries();
+        }
+    }
+
+    private async Task LoadPostsForSeries()
+    {
+        if (string.IsNullOrEmpty(model.SeriesId))
+        {
+            postsInSeries = [];
+            return;
+        }
+
+        var result = await BlogPostRepository.GetAllAsync(
+            filter: b => b.SeriesId == model.SeriesId,
+            orderBy: b => b.Order,
+            descending: false
+        );
+        postsInSeries = result.ToList();
+
+        // For a post that isn't part of the series yet (new post, or an existing post being
+        // assigned to a different series), place it at the end instead of the beginning.
+        var isInSeries = !string.IsNullOrEmpty(BlogPostId)
+            && postsInSeries.Any(p => p.Id == BlogPostId);
+        if (!isInSeries)
+        {
+            model.Order = postsInSeries.Count + 1;
+        }
+    }
+
+    private void OnDragStart(BlogPost post)
+    {
+        draggedPost = post;
+    }
+
+    private async Task OnDrop(BlogPost targetPost)
+    {
+        if (draggedPost == null || draggedPost.Id == targetPost.Id)
+        {
+            return;
+        }
+
+        var draggedIndex = postsInSeries.IndexOf(draggedPost);
+        var targetIndex = postsInSeries.IndexOf(targetPost);
+
+        postsInSeries.RemoveAt(draggedIndex);
+        postsInSeries.Insert(targetIndex, draggedPost);
+
+        // Update orders
+        for (int i = 0; i < postsInSeries.Count; i++)
+        {
+            postsInSeries[i].Order = i + 1;
+        }
+
+        await BlogPostRepository.StoreBulkAsync(postsInSeries);
+        ToastService.ShowSuccess("Series order updated");
+        draggedPost = null;
+        StateHasChanged();
+    }
+
+    private void ToggleAddSeries()
+    {
+        showAddSeries = !showAddSeries;
+        newSeriesTitle = string.Empty;
+    }
+
+    private async Task OnNewSeriesKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter")
+        {
+            await AddSeriesAsync();
+        }
+    }
+
+    private async Task AddSeriesAsync()
+    {
+        var title = newSeriesTitle?.Trim();
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            return;
+        }
+
+        var existing = blogSeries.FirstOrDefault(s => string.Equals(s.Name, title, StringComparison.OrdinalIgnoreCase));
+        if (existing is not null)
+        {
+            model.SeriesId = existing.Id;
+            await LoadPostsForSeries();
+            ToastService.ShowInfo("Series already exists; selected existing one");
+        }
+        else
+        {
+            var newSeries = new Series { Name = title };
+            await SeriesRepository.StoreAsync(newSeries);
+            blogSeries = (await SeriesRepository.GetAllAsync(orderBy: s => s.Name, descending: false)).ToList();
+            model.SeriesId = newSeries.Id;
+            await LoadPostsForSeries();
+            ToastService.ShowSuccess("Series created");
+        }
+
+        showAddSeries = false;
+        newSeriesTitle = string.Empty;
     }
 
     private string GetStatusText()

--- a/src/LinkDotNet.Blog.Web/Features/Admin/BlogPostEditor/Components/CreateNewModel.cs
+++ b/src/LinkDotNet.Blog.Web/Features/Admin/BlogPostEditor/Components/CreateNewModel.cs
@@ -10,6 +10,8 @@ public sealed class CreateNewModel
     private string id = default!;
     private DateTime? scheduledPublishDate;
     private string? authorName;
+    private string? seriesId;
+    private int order;
 
     [Required]
     [MaxLength(256)]
@@ -89,6 +91,18 @@ public sealed class CreateNewModel
         set => SetProperty(out authorName, value);
     }
 
+    public string? SeriesId
+    {
+        get => seriesId;
+        set => SetProperty(out seriesId, value);
+    }
+
+    public int Order
+    {
+        get => order;
+        set => SetProperty(out order, value);
+    }
+
     public bool IsDirty { get; private set; }
 
     public static CreateNewModel FromBlogPost(BlogPost blogPost)
@@ -108,6 +122,8 @@ public sealed class CreateNewModel
             PreviewImageUrlFallback = blogPost.PreviewImageUrlFallback ?? string.Empty,
             scheduledPublishDate = blogPost.ScheduledPublishDate?.ToUniversalTime(),
             authorName = blogPost.AuthorName,
+            seriesId = blogPost.SeriesId,
+            order = blogPost.Order,
             IsDirty = false,
         };
     }
@@ -131,7 +147,9 @@ public sealed class CreateNewModel
             scheduledPublishDate,
             tagList,
             PreviewImageUrlFallback,
-            AuthorName);
+            AuthorName,
+            SeriesId,
+            Order);
         blogPost.Id = id;
         return blogPost;
     }

--- a/src/LinkDotNet.Blog.Web/Features/Admin/Series/SeriesPage.razor
+++ b/src/LinkDotNet.Blog.Web/Features/Admin/Series/SeriesPage.razor
@@ -1,0 +1,321 @@
+@page "/series"
+@using System.ComponentModel.DataAnnotations
+@using LinkDotNet.Blog.Domain
+@using LinkDotNet.Blog.Infrastructure.Persistence
+@using Microsoft.AspNetCore.Authorization
+
+@attribute [Authorize]
+@inject IRepository<Series> SeriesRepository
+@inject IRepository<BlogPost> BlogPostRepository
+@inject IToastService ToastService
+
+<PageTitle>Blog Series</PageTitle>
+
+<div class="container">
+	<h3 class="fw-bold">Blog Series</h3>
+	<div class="alert alert-info" role="alert">
+		<h4 class="alert-heading">What are Blog Series?</h4>
+		<p>Blog series are a manual grouping of related blog posts that you want present to readers in a specific order. You can assign blog posts to a series when creating or editing blog posts or on this page.</p>
+		<p class="fst-italic">A blog post can only belong to one series.</p>
+	</div>
+	<EditForm Model="@model" OnValidSubmit="SaveSeries">
+		<DataAnnotationsValidator />
+		<div class="mb-3">
+			<label for="series-name" class="form-label">Series Name</label>
+			<InputText Id="series-name" class="form-control" @bind-Value="@model.Name" />
+			<ValidationMessage For="() => model.Name" />
+		</div>
+		<div class="d-flex justify-content-start gap-2">
+		<button type="submit" class="btn btn-primary">@(string.IsNullOrEmpty(model.Id) ? "Add Series" : "Save Series")</button>
+		@if (!string.IsNullOrEmpty(model.Id))
+		{
+			<button type="button" class="btn btn-secondary" @onclick="CancelEdit">Cancel</button>
+		}
+		</div>
+	</EditForm>
+	<hr>
+	@if (series.Count > 0)
+	{
+		<div class="accordion mt-3" id="seriesAccordion">
+			<label for="series-name" class="form-label"><b>Current Series:</b></label>
+			@foreach (var s in series)
+			{
+				<div class="accordion-item">
+					<h2 class="accordion-header" id="heading-@s.Id">
+						<button class="accordion-button @(expandedSeriesId == s.Id ? string.Empty : "collapsed")" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-@s.Id" aria-expanded="@(expandedSeriesId == s.Id)" aria-controls="collapse-@s.Id" @onclick="() => ToggleAccordion(s.Id)">
+							@s.Name
+						</button>
+					</h2>
+					<div id="collapse-@s.Id" class="accordion-collapse collapse @(expandedSeriesId == s.Id ? "show" : "")" aria-labelledby="heading-@s.Id">
+						<div class="accordion-body">
+                            <div class="mb-3">
+                                <h6>Blog Posts in this Series:</h6>
+                                <div class="list-group list-group-flush border rounded">
+                                    @if (postsInSeries.TryGetValue(s.Id, out var posts) && posts.Any())
+                                    {
+                                        @foreach (var post in posts)
+                                        {
+                                            <div class="list-group-item d-flex justify-content-between align-items-center"
+                                                 draggable="true"
+                                                 @ondragstart="() => OnDragStart(post)"
+                                                 @ondragover:preventDefault
+                                                 @ondrop="() => OnDrop(post, s.Id)">
+                                                <div>
+                                                    <i class="menu"></i> @post.Title
+                                                    @if (!post.IsPublished)
+                                                    {
+                                                        <span class="badge bg-secondary ms-2">Draft</span>
+                                                    }
+                                                </div>
+                                                <span class="badge bg-primary rounded-pill">@post.Order</span>
+                                            </div>
+                                        }
+                                    }
+                                    else
+                                    {
+                                        <div class="list-group-item text-muted small">No posts assigned to this series.</div>
+                                    }
+                                </div>
+                                <small class="text-muted mt-2 d-block">Drag and drop to reorder posts.</small>
+                            </div>
+                            <div class="mb-3">
+                                <h6>Add Blog Posts to this Series:</h6>
+                                <input type="text" class="form-control mb-2" placeholder="Search blog posts by title..."
+                                       value="@GetSearchTerm(s.Id)"
+                                       @oninput="e => OnSearchInput(s.Id, e.Value?.ToString() ?? string.Empty)" />
+                                @if (searchResults.TryGetValue(s.Id, out var results) && !string.IsNullOrWhiteSpace(GetSearchTerm(s.Id)))
+                                {
+                                    <div class="list-group list-group-flush border rounded" style="max-height: 240px; overflow-y: auto;">
+                                        @if (results.Count == 0)
+                                        {
+                                            <div class="list-group-item text-muted small">No matching posts found.</div>
+                                        }
+                                        else
+                                        {
+                                            @foreach (var post in results)
+                                            {
+                                                <div class="list-group-item d-flex justify-content-between align-items-center">
+                                                    <div>
+                                                        @post.Title
+                                                        @if (!post.IsPublished)
+                                                        {
+                                                            <span class="badge bg-secondary ms-2">Draft</span>
+                                                        }
+                                                        @if (!string.IsNullOrEmpty(post.SeriesId) && post.SeriesId != s.Id)
+                                                        {
+                                                            <span class="badge bg-warning text-dark ms-2">In another series</span>
+                                                        }
+                                                    </div>
+                                                    <button type="button" class="btn btn-sm btn-success" @onclick="() => AddPostToSeries(post, s.Id)">
+                                                        Add
+                                                    </button>
+                                                </div>
+                                            }
+                                        }
+                                    </div>
+                                }
+                            </div>
+							<hr/>
+							<div class="d-flex justify-content-start gap-2">
+								<button id="edit-series" type="button" class="btn btn-primary d-flex align-items-center gap-2" @onclick="() => EditSeries(s)" aria-label="edit">
+									<i class="pencil"></i>
+									<div class="vr"></div><span>Edit</span>
+								</button>
+								<button id="delete-series" type="button" class="btn btn-danger d-flex align-items-center gap-2" @onclick="() => DeleteSeries(s.Id)" aria-label="delete">
+									<i class="bin2"></i>
+									<div class="vr"></div><span>Delete</span>
+								</button>
+							</div>
+						</div>
+					</div>
+				</div>
+			}
+		</div>
+	} else
+    {
+	    <p>No series exist.</p>
+    }
+</div>
+
+@code {
+    private Model model = new();
+    private List<Series> series = [];
+    private string? expandedSeriesId;
+    private Dictionary<string, List<BlogPost>> postsInSeries = new();
+    private BlogPost? draggedPost;
+    private Dictionary<string, string> searchTerms = new();
+    private Dictionary<string, List<BlogPost>> searchResults = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        series = (await SeriesRepository.GetAllAsync(orderBy: s => s.Name, descending: false)).ToList();
+    }
+
+    private async Task ToggleAccordion(string seriesId)
+    {
+        expandedSeriesId = expandedSeriesId == seriesId ? null : seriesId;
+        if (expandedSeriesId != null && !postsInSeries.ContainsKey(expandedSeriesId))
+        {
+            await LoadPostsForSeries(expandedSeriesId);
+        }
+    }
+
+    private async Task LoadPostsForSeries(string seriesId)
+    {
+        var result = await BlogPostRepository.GetAllAsync(
+            filter: b => b.SeriesId == seriesId,
+            orderBy: b => b.Order,
+            descending: false
+        );
+        postsInSeries[seriesId] = result.ToList();
+    }
+
+    private void OnDragStart(BlogPost post)
+    {
+        draggedPost = post;
+    }
+
+    private async Task OnDrop(BlogPost targetPost, string seriesId)
+    {
+        if (draggedPost == null || draggedPost.Id == targetPost.Id || draggedPost.SeriesId != seriesId)
+        {
+            return;
+        }
+
+        var posts = postsInSeries[seriesId];
+        var draggedIndex = posts.IndexOf(draggedPost);
+        var targetIndex = posts.IndexOf(targetPost);
+
+        posts.RemoveAt(draggedIndex);
+        posts.Insert(targetIndex, draggedPost);
+
+        // Update order
+        for (int i = 0; i < posts.Count; i++)
+        {
+            posts[i].Order = i + 1;
+        }
+
+        await BlogPostRepository.StoreBulkAsync(posts);
+        ToastService.ShowSuccess("Order updated");
+        draggedPost = null;
+        StateHasChanged();
+    }
+
+    private async Task SaveSeries()
+    {
+        if (!string.IsNullOrEmpty(model.Id))
+        {
+            var existing = series.FirstOrDefault(s => s.Id == model.Id);
+            if (existing != null)
+            {
+                existing.Name = model.Name;
+                await SeriesRepository.StoreAsync(existing);
+
+                // Refresh cached blog posts that assigned to this series so updated name appears on blog posts
+                var assignedPosts = (await BlogPostRepository.GetAllAsync(filter: b => b.SeriesId == existing.Id)).ToList();
+                foreach (var post in assignedPosts)
+                {
+                    await BlogPostRepository.StoreAsync(post);
+                }
+
+                ToastService.ShowSuccess("Series updated");
+            }
+        }
+        else
+        {
+            var newSeries = new Series { Name = model.Name };
+            await SeriesRepository.StoreAsync(newSeries);
+            series.Add(newSeries);
+            series = series.OrderBy(s => s.Name).ToList();
+            ToastService.ShowSuccess("Series created");
+        }
+
+        model = new Model();
+    }
+
+    private async Task DeleteSeries(string id)
+    {
+        var assignedPosts = (await BlogPostRepository.GetAllAsync(filter: b => b.SeriesId == id)).ToList();
+        foreach (var post in assignedPosts)
+        {
+            post.RemoveFromSeries();
+            await BlogPostRepository.StoreAsync(post);
+        }
+
+        await SeriesRepository.DeleteAsync(id);
+        series.RemoveAll(s => s.Id == id);
+        postsInSeries.Remove(id);
+        if (expandedSeriesId == id)
+        {
+            expandedSeriesId = null;
+        }
+        ToastService.ShowSuccess("Series deleted");
+    }
+
+    private void EditSeries(Series s)
+    {
+        model.Id = s.Id;
+        model.Name = s.Name;
+    }
+
+    private void CancelEdit()
+    {
+        model = new Model();
+    }
+
+    private string GetSearchTerm(string seriesId) =>
+        searchTerms.TryGetValue(seriesId, out var term) ? term : string.Empty;
+
+    private async Task OnSearchInput(string seriesId, string term)
+    {
+        searchTerms[seriesId] = term;
+
+        var trimmed = term?.Trim() ?? string.Empty;
+        if (string.IsNullOrEmpty(trimmed))
+        {
+            searchResults.Remove(seriesId);
+            return;
+        }
+
+        var lowered = trimmed.ToLowerInvariant();
+        var matches = await BlogPostRepository.GetAllAsync(
+            filter: b => b.SeriesId != seriesId && b.Title.ToLower().Contains(lowered),
+            orderBy: b => b.Title,
+            descending: false,
+            page: 1,
+            pageSize: 20);
+        searchResults[seriesId] = matches.ToList();
+    }
+
+    private async Task AddPostToSeries(BlogPost post, string seriesId)
+    {
+        if (!postsInSeries.ContainsKey(seriesId))
+        {
+            await LoadPostsForSeries(seriesId);
+        }
+
+        var posts = postsInSeries[seriesId];
+        post.AssignToSeries(seriesId, posts.Count + 1);
+        await BlogPostRepository.StoreAsync(post);
+
+        posts.Add(post);
+        postsInSeries[seriesId] = posts;
+
+        if (searchResults.TryGetValue(seriesId, out var results))
+        {
+            results.RemoveAll(p => p.Id == post.Id);
+        }
+
+        ToastService.ShowSuccess($"Added \"{post.Title}\" to the series");
+        StateHasChanged();
+    }
+
+    private sealed class Model
+    {
+        public string Id { get; set; } = string.Empty;
+
+        [Required]
+        [MaxLength(256)]
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/src/LinkDotNet.Blog.Web/Features/Home/Components/AccessControl.razor
+++ b/src/LinkDotNet.Blog.Web/Features/Home/Components/AccessControl.razor
@@ -14,6 +14,7 @@
                 <li><a class="dropdown-item" href="create">Create new</a></li>
                 <li><a class="dropdown-item" href="draft">Show drafts</a></li>
                 <li><a class="dropdown-item" href="settings">Show settings</a></li>
+                <li><a class="dropdown-item" href="series">Show blog series</a></li>
                 <li><hr class="dropdown-divider"></li>
                 <li><h6 class="dropdown-header">Analytics</h6></li>
                 <li><a class="dropdown-item" href="dashboard">Dashboard</a></li>

--- a/src/LinkDotNet.Blog.Web/Features/ShowBlogPost/Components/SeriesNavigation.razor
+++ b/src/LinkDotNet.Blog.Web/Features/ShowBlogPost/Components/SeriesNavigation.razor
@@ -1,0 +1,44 @@
+@using LinkDotNet.Blog.Domain
+@using LinkDotNet.Blog.Infrastructure.Persistence
+@inject IRepository<BlogPost> BlogPostRepository
+
+@if (Series != null)
+{
+    <div class="card mb-4">
+        <div class="card-body">
+            <h5 class="card-title text-primary">Series: @Series.Name</h5>
+            <div class="list-group list-group-flush small">
+	            @for (var i = 0; i < postsInSeries.Count; i++)
+	            {
+		            var post = postsInSeries[i];
+		            <a href="/blogPost/@post.Id/@post.Slug" class="list-group-item list-group-item-action @(post.Id == CurrentBlogPostId ? "active" : "") py-1">
+			            @(i + 1). @post.Title
+		            </a>
+	            }
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter, EditorRequired]
+    public Series? Series { get; set; }
+
+    [Parameter, EditorRequired]
+    public required string CurrentBlogPostId { get; set; }
+
+    private List<BlogPost> postsInSeries = [];
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (Series != null)
+        {
+            var result = await BlogPostRepository.GetAllAsync(
+                filter: b => b.SeriesId == Series.Id && b.IsPublished,
+                orderBy: b => b.Order,
+                descending: false
+            );
+            postsInSeries = result.ToList();
+        }
+    }
+}

--- a/src/LinkDotNet.Blog.Web/Features/ShowBlogPost/ShowBlogPostPage.razor
+++ b/src/LinkDotNet.Blog.Web/Features/ShowBlogPost/ShowBlogPostPage.razor
@@ -90,6 +90,10 @@ else if (BlogPost is not null)
 				<div class="blogpost-content">
 					@(EnrichWithShortCodes(BlogPost.Content))
 				</div>
+
+				<div class="pt-2">
+					<SeriesNavigation Series="@BlogPost.Series" CurrentBlogPostId="@BlogPost.Id"></SeriesNavigation>
+				</div>
 			</div>
 			<div class="d-flex justify-content-between py-2 border-top border-bottom align-items-center">
 				<Like BlogPost="@BlogPost" OnBlogPostLiked="@UpdateLikes"></Like>


### PR DESCRIPTION
Closes #523 (potential future improvements still in 523)

The changes for the files in the Persistence folder I am unsure about due to my lack of experience, _disclaimer used AI to generate those changes_. I am also curious if how I cache busted is the right way to go (if a series was renamed or deleted - then the blog posts would still have the old name or still be referencing a deleted series)

**Added series display for readers on blog posts (if blog is assigned to a series)**
<img width="1221" height="512" alt="image" src="https://github.com/user-attachments/assets/91eaab6d-c05c-417d-a45c-8d470558ccf3" />
**Admin can assigned blogs to series when creating or editing a blog post, and can reorder posts as well**
<img width="655" height="390" alt="image" src="https://github.com/user-attachments/assets/85273b76-7cc9-43d8-b5e0-5d6a34e881fe" />
**New admin page /series to manage series (add/delete/assign/order)**
<img width="1371" height="880" alt="image" src="https://github.com/user-attachments/assets/8ce56141-cde3-4a35-80a6-d678d2aa06e8" />